### PR TITLE
Support pagination

### DIFF
--- a/lib/service_contract_webmock/contract_matcher.rb
+++ b/lib/service_contract_webmock/contract_matcher.rb
@@ -1,4 +1,4 @@
-require 'cgi'
+require 'rack'
 require 'avro'
 
 module ServiceContractWebmock
@@ -14,7 +14,7 @@ module ServiceContractWebmock
 
     def to_regex
       params = fields_and_pagination.map do |field|
-        "#{field.name}=#{field.value}&?"
+        "#{field.name}(%5B%5D)?=#{field.value}&?"
       end.join("|")
       "(#{params})+"
     end
@@ -55,12 +55,6 @@ module ServiceContractWebmock
     end
 
     def found(query)
-      records = do_search(query)
-
-      apply_pagination(records, query)
-    end
-
-    def do_search(query)
       search = extract_request(query)
       if search.empty?
         resources
@@ -74,13 +68,5 @@ module ServiceContractWebmock
       end
     end
 
-    def apply_pagination(records, query)
-      params = CGI.parse(query)
-      if params["per_page"].present? && params["per_page"].first.present?
-        per_page = params["per_page"].first.to_i
-        records = records.take(per_page)
-      end
-      records
-    end
-  end
+ end
 end


### PR DESCRIPTION
Original PR here https://github.com/dplummer/service_contract_webmock/pull/3

This gem supports most of our test suite that involves JSON API clients (almost everything). It reads the Avro contracts for a service and (web)mocks all the available requests (index, show, search, etc) with a given mock array of resources (usually an array of hashes representing the resource E.g. `Account::User`).

A good example of this is in Banana Stand - https://github.com/avvo/banana_stand/blob/master/spec/support/service_mocks.rb

----

This change allows the mocked result to support pagination, which wasn't available before.